### PR TITLE
Deal with concurrency in PlantDescriptionTracker

### DIFF
--- a/plantdescriptionengine/pom.xml
+++ b/plantdescriptionengine/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <kalix.version>0.6.0</kalix.version>
+        <kalix.version>0.6.1</kalix.version>
         <mysql.jdbc.driver>8.0.16</mysql.jdbc.driver>
     </properties>
 

--- a/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/SystemMismatchDetector.java
+++ b/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/SystemMismatchDetector.java
@@ -13,6 +13,7 @@ import eu.arrowhead.core.plantdescriptionengine.providedservices.pde_mgmt.dto.Pl
 import eu.arrowhead.core.plantdescriptionengine.utils.Metadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import se.arkalix.util.concurrent.Future;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,27 +55,30 @@ public class SystemMismatchDetector implements PlantDescriptionUpdateListener, S
     }
 
     @Override
-    public void onPlantDescriptionAdded(final PlantDescriptionEntry entry) {
+    public Future<Void> onPlantDescriptionAdded(final PlantDescriptionEntry entry) {
         Objects.requireNonNull(entry, "Expected entry.");
         logger.debug("Entry '" + entry.plantDescription() + "' added, checking for inconsistencies...");
         updateAlarms();
+        return Future.done();
     }
 
     @Override
-    public void onPlantDescriptionUpdated(
+    public Future<Void> onPlantDescriptionUpdated(
         final PlantDescriptionEntry updatedEntry,
         final PlantDescriptionEntry oldEntry
     ) {
         Objects.requireNonNull(updatedEntry, "Expected entry.");
         logger.debug("Entry '" + updatedEntry.plantDescription() + "' updated, checking for inconsistencies...");
         updateAlarms();
+        return Future.done();
     }
 
     @Override
-    public void onPlantDescriptionRemoved(final PlantDescriptionEntry entry) {
+    public Future<Void> onPlantDescriptionRemoved(final PlantDescriptionEntry entry) {
         Objects.requireNonNull(entry, "Expected entry.");
         logger.debug("Entry '" + entry.plantDescription() + "' removed, checking for inconsistencies...");
         updateAlarms();
+        return Future.done();
     }
 
     @Override

--- a/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/pdtracker/PlantDescriptionUpdateListener.java
+++ b/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/pdtracker/PlantDescriptionUpdateListener.java
@@ -1,11 +1,12 @@
 package eu.arrowhead.core.plantdescriptionengine.pdtracker;
 
 import eu.arrowhead.core.plantdescriptionengine.providedservices.pde_mgmt.dto.PlantDescriptionEntry;
+import se.arkalix.util.concurrent.Future;
 
 public interface PlantDescriptionUpdateListener {
-    void onPlantDescriptionAdded(PlantDescriptionEntry entry);
+    Future<?> onPlantDescriptionAdded(PlantDescriptionEntry entry);
 
-    void onPlantDescriptionUpdated(PlantDescriptionEntry newState, PlantDescriptionEntry oldState);
+    Future<?> onPlantDescriptionUpdated(PlantDescriptionEntry newState, PlantDescriptionEntry oldState);
 
-    void onPlantDescriptionRemoved(PlantDescriptionEntry entry);
+    Future<?> onPlantDescriptionRemoved(PlantDescriptionEntry entry);
 }

--- a/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_mgmt/routehandlers/DeletePlantDescription.java
+++ b/plantdescriptionengine/src/main/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_mgmt/routehandlers/DeletePlantDescription.java
@@ -80,16 +80,14 @@ public class DeletePlantDescription implements HttpRouteHandler {
             return Future.success(response);
         }
 
-        try {
-            pdTracker.remove(id);
-        } catch (final PdStoreException e) {
-            logger.error("Failed to remove Plant Description Entry from backing store", e);
-            response
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorMessage.of("Encountered an error while deleting entry file."), CodecType.JSON);
-            return Future.success(response);
-        }
-
-        return Future.success(response.status(HttpStatus.OK));
+        return pdTracker.remove(id)
+            .map(result -> response.status(HttpStatus.OK))
+            .mapCatch(PdStoreException.class, e -> {
+                logger.error("Failed to remove Plant Description Entry from backing store", e);
+                response
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ErrorMessage.of("Encountered an error while deleting entry file."), CodecType.JSON);
+                return response;
+            });
     }
 }

--- a/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_mgmt/routehandlers/GetPlantDescriptionTest.java
+++ b/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_mgmt/routehandlers/GetPlantDescriptionTest.java
@@ -52,17 +52,15 @@ public class GetPlantDescriptionTest {
     }
 
     @Test
-    public void shouldRespondWithStoredEntry() throws PdStoreException {
+    public void shouldRespondWithStoredEntry() {
 
         final int entryId = 39;
-
-        pdTracker.put(TestUtils.createEntry(entryId));
-
         final HttpServiceRequest request = new MockRequest.Builder()
             .pathParameters(List.of(String.valueOf(entryId)))
             .build();
 
-        handler.handle(request, response)
+        pdTracker.put(TestUtils.createEntry(entryId))
+            .flatMap(result -> handler.handle(request, response))
             .ifSuccess(result -> {
                 assertEquals(HttpStatus.OK, response.status().orElse(null));
                 final PlantDescriptionEntry returnedEntry = (PlantDescriptionEntry) response.getRawBody();
@@ -76,18 +74,16 @@ public class GetPlantDescriptionTest {
     }
 
     @Test
-    public void shouldNotAcceptInvalidId() throws PdStoreException {
+    public void shouldNotAcceptInvalidId() {
 
         final int entryId = 24;
         final String invalidId = "Invalid";
-
-        pdTracker.put(TestUtils.createEntry(entryId));
-
         final HttpServiceRequest request = new MockRequest.Builder()
             .pathParameters(List.of(invalidId))
             .build();
 
-        handler.handle(request, response)
+        pdTracker.put(TestUtils.createEntry(entryId))
+            .flatMap(result -> handler.handle(request, response))
             .ifSuccess(result -> assertEquals(
                 HttpStatus.BAD_REQUEST, response.status().orElse(null)
             ))

--- a/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_monitor/routehandlers/DtoUtilsTest.java
+++ b/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_monitor/routehandlers/DtoUtilsTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DtoUtilsTest {
 
@@ -104,7 +105,7 @@ public class DtoUtilsTest {
     }
 
     @Test
-    public void shouldPlaceMonitorDataOnPortLevel() throws PdStoreException {
+    public void shouldPlaceMonitorDataOnPortLevel() {
         final Map<String, String> serviceMetadata = Map.of("a", "b");
         final List<PortDto> ports = List.of(
             new PortDto.Builder()
@@ -140,24 +141,26 @@ public class DtoUtilsTest {
 
         monitorInfoTracker.putInventoryId(ServiceRecord, inventoryId);
         monitorInfoTracker.putSystemData(ServiceRecord, systemData);
-        pdTracker.put(entry);
+        pdTracker.put(entry)
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
+                final SystemEntry extendedSystem = extendedEntry.systems().get(0);
 
-        final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
-        final SystemEntry extendedSystem = extendedEntry.systems().get(0);
+                final PortEntry monitorablePort = extendedSystem.ports().get(0);
+                final PortEntry extendedPortA = extendedSystem.ports().get(1);
+                final PortEntry extendedPortB = extendedSystem.ports().get(2);
+                final PortEntry extendedPortC = extendedSystem.ports().get(3);
 
-        final PortEntry monitorablePort = extendedSystem.ports().get(0);
-        final PortEntry extendedPortA = extendedSystem.ports().get(1);
-        final PortEntry extendedPortB = extendedSystem.ports().get(2);
-        final PortEntry extendedPortC = extendedSystem.ports().get(3);
-
-        assertTrue(hasNoMonitorInfo(monitorablePort));
-        assertTrue(hasNoMonitorInfo(extendedPortA));
-        assertTrue(hasNoMonitorInfo(extendedPortB));
-        assertTrue(hasMonitorInfo(extendedPortC, inventoryId, systemData));
+                assertTrue(hasNoMonitorInfo(monitorablePort));
+                assertTrue(hasNoMonitorInfo(extendedPortA));
+                assertTrue(hasNoMonitorInfo(extendedPortB));
+                assertTrue(hasMonitorInfo(extendedPortC, inventoryId, systemData));
+            })
+            .onFailure(e -> fail());
     }
 
     @Test
-    public void shouldNotPlaceMonitorInfoOnMonitorablePort() throws PdStoreException {
+    public void shouldNotPlaceMonitorInfoOnMonitorablePort() {
         final Map<String, String> serviceMetadata = Map.of("a", "b");
         final List<PortDto> ports = List.of(
             new PortDto.Builder()
@@ -174,17 +177,19 @@ public class DtoUtilsTest {
 
         monitorInfoTracker.putInventoryId(ServiceRecord, inventoryId);
         monitorInfoTracker.putSystemData(ServiceRecord, systemData);
-        pdTracker.put(entry);
+        pdTracker.put(entry)
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
+                final SystemEntry extendedSystem = extendedEntry.systems().get(0);
+                final PortEntry monitorablePort = extendedSystem.ports().get(0);
 
-        final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
-        final SystemEntry extendedSystem = extendedEntry.systems().get(0);
-        final PortEntry monitorablePort = extendedSystem.ports().get(0);
-
-        assertTrue(hasNoMonitorInfo(monitorablePort));
+                assertTrue(hasNoMonitorInfo(monitorablePort));
+            })
+            .onFailure(e -> fail());
     }
 
     @Test
-    public void shouldPlaceMonitorDataOnSystemLevel() throws PdStoreException {
+    public void shouldPlaceMonitorDataOnSystemLevel() {
 
         final Map<String, String> systemMetadata = Map.of("x", "0", "y", "1", "z", "2");
         final Map<String, String> serviceMetadata = Map.of("foo", "bar");
@@ -214,21 +219,23 @@ public class DtoUtilsTest {
 
         monitorInfoTracker.putInventoryId(ServiceRecord, inventoryId);
         monitorInfoTracker.putSystemData(ServiceRecord, systemData);
-        pdTracker.put(entry);
+        pdTracker.put(entry)
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
+                final SystemEntry extendedSystem = extendedEntry.systems().get(0);
 
-        final MonitorPlantDescriptionEntry extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
-        final SystemEntry extendedSystem = extendedEntry.systems().get(0);
+                final PortEntry extendedPortA = extendedSystem.ports().get(0);
+                final PortEntry extendedPortB = extendedSystem.ports().get(1);
 
-        final PortEntry extendedPortA = extendedSystem.ports().get(0);
-        final PortEntry extendedPortB = extendedSystem.ports().get(1);
-
-        assertTrue(hasNoMonitorInfo(extendedPortA));
-        assertTrue(hasNoMonitorInfo(extendedPortB));
-        assertTrue(hasMonitorInfo(extendedSystem, inventoryId, systemData));
+                assertTrue(hasNoMonitorInfo(extendedPortA));
+                assertTrue(hasNoMonitorInfo(extendedPortB));
+                assertTrue(hasMonitorInfo(extendedSystem, inventoryId, systemData));
+            })
+            .onFailure(e -> fail());
     }
 
     @Test
-    public void shouldExtendWithoutMonitorData() throws PdStoreException {
+    public void shouldExtendWithoutMonitorData() {
         final PortDto port = new PortDto.Builder()
             .portName("Port-A")
             .serviceInterface(httpSecureJson)
@@ -237,15 +244,17 @@ public class DtoUtilsTest {
         final PdeSystemDto system = getSystemWithPorts(List.of(port));
         final PlantDescriptionEntryDto entry = getEntryWithSystem(system);
 
-        pdTracker.put(entry);
+        pdTracker.put(entry)
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntryDto extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
+                final SystemEntry extendedSystem = extendedEntry.systems().get(0);
+                final PortEntry extendedPort = extendedSystem.ports().get(0);
 
-        final MonitorPlantDescriptionEntryDto extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
-        final SystemEntry extendedSystem = extendedEntry.systems().get(0);
-        final PortEntry extendedPort = extendedSystem.ports().get(0);
-
-        assertTrue(extendedPort.inventoryId().isEmpty());
-        assertTrue(extendedPort.systemData().isEmpty());
-        assertEquals(httpSecureJson, extendedPort.serviceInterface().orElse(null));
+                assertTrue(extendedPort.inventoryId().isEmpty());
+                assertTrue(extendedPort.systemData().isEmpty());
+                assertEquals(httpSecureJson, extendedPort.serviceInterface().orElse(null));
+            })
+            .onFailure(e -> fail());
     }
 
     /**
@@ -254,7 +263,7 @@ public class DtoUtilsTest {
      * allowed. This is enforced by the {@link eu.arrowhead.core.plantdescriptionengine.providedservices.pde_mgmt.PlantDescriptionValidator}.
      */
     @Test
-    public void shouldNotAddMonitorDataToConsumerPort() throws PdStoreException {
+    public void shouldNotAddMonitorDataToConsumerPort() {
         final Map<String, String> serviceMetadata = Map.of("a", "b");
         final PortDto port = new PortDto.Builder()
             .metadata(serviceMetadata)
@@ -270,13 +279,15 @@ public class DtoUtilsTest {
 
         monitorInfoTracker.putInventoryId(ServiceRecord, inventoryId);
         monitorInfoTracker.putSystemData(ServiceRecord, systemData);
-        pdTracker.put(entry);
+        pdTracker.put(entry)
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntryDto extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
+                final SystemEntry extendedSystem = extendedEntry.systems().get(0);
+                final PortEntry extendedPortA = extendedSystem.ports().get(0);
 
-        final MonitorPlantDescriptionEntryDto extendedEntry = DtoUtils.extend(entry, monitorInfoTracker, pdTracker);
-        final SystemEntry extendedSystem = extendedEntry.systems().get(0);
-        final PortEntry extendedPortA = extendedSystem.ports().get(0);
-
-        assertTrue(hasNoMonitorInfo(extendedPortA));
+                assertTrue(hasNoMonitorInfo(extendedPortA));
+            })
+            .onFailure(e -> fail());
     }
 
 }

--- a/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_monitor/routehandlers/GetPlantDescriptionTest.java
+++ b/plantdescriptionengine/src/test/java/eu/arrowhead/core/plantdescriptionengine/providedservices/pde_monitor/routehandlers/GetPlantDescriptionTest.java
@@ -53,36 +53,34 @@ public class GetPlantDescriptionTest {
     }
 
     @Test
-    public void shouldRespondWithStoredEntry() throws PdStoreException {
+    public void shouldRespondWithStoredEntry() {
 
         final int entryId = 39;
-
-        pdTracker.put(TestUtils.createEntry(entryId));
-
         final HttpServiceRequest request = new MockRequest.Builder()
             .pathParameters(List.of(String.valueOf(entryId)))
             .build();
 
-        handler.handle(request, response).ifSuccess(result -> {
-            final MonitorPlantDescriptionEntry returnedEntry = (MonitorPlantDescriptionEntry) response.getRawBody();
-            assertEquals(HttpStatus.OK, response.status().orElse(null));
-            assertEquals(returnedEntry.id(), entryId);
-        }).onFailure(e -> fail());
+        pdTracker.put(TestUtils.createEntry(entryId))
+            .flatMap(result -> handler.handle(request, response))
+            .ifSuccess(result -> {
+                final MonitorPlantDescriptionEntry returnedEntry = (MonitorPlantDescriptionEntry) response.getRawBody();
+                assertEquals(HttpStatus.OK, response.status().orElse(null));
+                assertEquals(returnedEntry.id(), entryId);
+            })
+            .onFailure(e -> fail());
     }
 
     @Test
-    public void shouldNotAcceptInvalidId() throws PdStoreException {
+    public void shouldNotAcceptInvalidId() {
 
         final int entryId = 24;
         final String invalidId = "Invalid";
-
-        pdTracker.put(TestUtils.createEntry(entryId));
-
         final HttpServiceRequest request = new MockRequest.Builder()
             .pathParameters(List.of(invalidId))
             .build();
 
-        handler.handle(request, response)
+        pdTracker.put(TestUtils.createEntry(entryId))
+            .flatMap(result -> handler.handle(request, response))
             .ifSuccess(result -> assertEquals(HttpStatus.BAD_REQUEST, response.status().orElse(null)))
             .onFailure(e -> fail());
     }


### PR DESCRIPTION
Improved concurrency handling in PDE. The PDE now waits until all async subtasks have completed (or failed) before accepting new state-modifying requests.